### PR TITLE
Msg converter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+DerivePointerAlignment: false
+IndentWidth: 4
+PointerAlignment: Left
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  BeforeElse: true
+  BeforeCatch: true
+NamespaceIndentation: All
+CommentPragmas:  '^\\.+'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,4 +153,5 @@ target_link_libraries(
         PRIVATE tomcat_model_lib
         ${Boost_LIBRARIES}
         Eigen3::Eigen
-        nlohmann_json::nlohmann_json)
+        nlohmann_json::nlohmann_json
+        fmt::fmt)

--- a/src/convert_messages.cpp
+++ b/src/convert_messages.cpp
@@ -17,6 +17,7 @@ void convert_ta3_messages(const string& map_config_path,
                           const string& messages_input_dir,
                           const string& output_dir) {
     TA3MessageConverter converter(map_config_path);
+
     converter.convert_offline(messages_input_dir, output_dir);
 }
 
@@ -37,7 +38,7 @@ int main(int argc, char* argv[]) {
         "Directory where the files with the messages are stored.")(
         "output_dir",
         po::value<string>(&output_dir)
-            ->default_value("../../data/samples/ta3/falcon/human/v2"),
+            ->default_value("../../data/samples/ta3/falcon"),
         "Directory where the files with evidence extracted from the messages "
         "must be saved.");
 

--- a/src/converter/MessageConverter.h
+++ b/src/converter/MessageConverter.h
@@ -64,8 +64,9 @@ namespace tomcat {
              * @param output_dir: directory where node's observations over
              * mission samples and time steps must be saved
              */
-            virtual void convert_offline(const std::string& input_dir,
-                                 const std::string& output_dir) = 0;
+            virtual void
+            convert_offline(const std::string& input_dir,
+                            const std::string& output_dir) = 0;
 
             /**
              * Parses a json message object and, if related to an observation of

--- a/src/converter/TA3MessageConverter.cpp
+++ b/src/converter/TA3MessageConverter.cpp
@@ -1,6 +1,7 @@
 #include "TA3MessageConverter.h"
 
 #include <iostream>
+#include <iomanip>
 
 #include <boost/progress.hpp>
 #include <fmt/format.h>

--- a/src/converter/TA3MessageConverter.h
+++ b/src/converter/TA3MessageConverter.h
@@ -71,6 +71,31 @@ namespace tomcat {
 
           private:
             //------------------------------------------------------------------
+            // Static functions
+            //------------------------------------------------------------------
+
+            /**
+             * Reads messages from a file and returns them sorted by timestamp.
+             *
+             * @param filepath: path of the file where the messages are stored.
+             *
+             * @return Sorted messages
+             */
+            static std::vector<nlohmann::json>
+            get_sorted_messages_in(const std::string& filepath);
+
+            /**
+             * Converts a string with remaining minutes and seconds to the total
+             * number of seconds for the mission to end.
+             *
+             * @param time: string containing the remaining time formatted (mm :
+             * ss)
+             *
+             * @return Remaining time in seconds.
+             */
+            int get_remaining_seconds_from(const std::string& time);
+
+            //------------------------------------------------------------------
             // Member functions
             //------------------------------------------------------------------
 
@@ -87,27 +112,6 @@ namespace tomcat {
              */
             void
             load_map_area_configuration(const std::string& map_config_filepath);
-
-            /**
-             * Reads messages from a file and returns them sorted by timestamp.
-             *
-             * @param filepath: path of the file where the messages are stored.
-             *
-             * @return Sorted messages
-             */
-            std::vector<nlohmann::json>
-            get_sorted_messages_in(const std::string& filepath);
-
-            /**
-             * Converts a string with remaining minutes and seconds to the total
-             * number of seconds for the mission to end.
-             *
-             * @param time: string containing the remaining time formatted (mm :
-             * ss)
-             *
-             * @return Remaining time in seconds.
-             */
-            int get_remaining_seconds_from(const std::string& time);
 
             /**
              * Returns observation related to victim saving.

--- a/src/experiments/Experimentation.cpp
+++ b/src/experiments/Experimentation.cpp
@@ -221,6 +221,7 @@ namespace tomcat {
             pipeline.set_estimation_process(this->offline_estimation);
             pipeline.set_aggregator(this->evaluation);
             pipeline.execute();
+            output_file.close();
         }
 
         void Experimentation::train_and_save() {

--- a/src/utils/EigenExtensions.cpp
+++ b/src/utils/EigenExtensions.cpp
@@ -54,12 +54,15 @@ namespace tomcat {
         }
 
         Eigen::MatrixXd
-        standard_error(const vector<Eigen::MatrixXd>& matrices){
+        standard_error(const vector<Eigen::MatrixXd>& matrices) {
             Eigen::MatrixXd mean_matrix = mean(matrices);
-            Eigen::MatrixXd se_matrix = (matrices[0].array() - mean_matrix.array()).pow(2).matrix();
+            Eigen::MatrixXd se_matrix =
+                (matrices[0].array() - mean_matrix.array()).pow(2).matrix();
 
             for (int i = 1; i < matrices.size(); i++) {
-                se_matrix = se_matrix + (matrices[i].array() - mean_matrix.array()).pow(2).matrix();
+                se_matrix =
+                    se_matrix +
+                    (matrices[i].array() - mean_matrix.array()).pow(2).matrix();
             }
 
             se_matrix = (se_matrix.array().sqrt() / matrices.size()).matrix();
@@ -77,6 +80,18 @@ namespace tomcat {
             stringstream ss;
             ss << matrix;
             return ss.str();
+        }
+
+        void vstack(Eigen::MatrixXd& original_matrix,
+                    const Eigen::MatrixXd& other_matrix) {
+
+            int old_rows = original_matrix.rows();
+            int new_rows = old_rows + other_matrix.rows();
+            int cols = other_matrix.cols();
+
+            original_matrix.conservativeResize(new_rows, cols);
+            original_matrix.block(old_rows, 0, other_matrix.rows(), cols) =
+                other_matrix;
         }
 
     } // namespace model

--- a/src/utils/EigenExtensions.h
+++ b/src/utils/EigenExtensions.h
@@ -56,5 +56,14 @@ namespace tomcat {
          */
         std::string to_string(const Eigen::MatrixXd& matrix);
 
+        /**
+         * Appends a matrix in the original one rowwise.
+         *
+         * @param original_matrix: matrix to be appended
+         * @param other_matrix: matrix to append in the original one
+         */
+        void vstack(Eigen::MatrixXd& original_matrix,
+                    const Eigen::MatrixXd& other_matrix);
+
     } // namespace model
 } // namespace tomcat

--- a/src/utils/FileHandler.cpp
+++ b/src/utils/FileHandler.cpp
@@ -37,7 +37,12 @@ namespace tomcat {
         }
 
         Eigen::MatrixXd read_matrix_from_file(const string& filepath) {
-            return read_tensor_from_file(filepath)(0, 0);
+            Tensor3 tensor = read_tensor_from_file(filepath);
+            if (tensor.is_empty()) {
+                return Eigen::MatrixXd(0,0);
+            } else {
+                return tensor(0, 0);
+            }
         }
 
         void save_tensor_to_file(const string& filepath,
@@ -58,8 +63,9 @@ namespace tomcat {
             bool started_reading_matrix = false;
             double* buffer = new double[MAXBUFSIZE];
             ifstream file_reader(filepath);
+            bool is_empty = file_reader.peek() == ifstream::traits_type ::eof();
 
-            while (true) {
+            while (!is_empty) {
                 // if (line.replace(line.begin(), line.end(), " ", "").empty())
                 // {
                 string line;

--- a/tools/install
+++ b/tools/install
@@ -29,7 +29,6 @@ __build_tmm() {
                 NJOBS=$(sysctl -n hw.ncpu)
             fi
 
-            # On CI, we build the examples by default.
             if ! cmake ${ROOT}; then exit 1; fi
 
             if ! make -j $NJOBS; then exit 1; fi

--- a/tools/install_dependencies
+++ b/tools/install_dependencies
@@ -35,7 +35,25 @@ __install_dependencies_using_homebrew() {
 
     echo "Installing ToMCAT dependencies using Homebrew."
 
-    if ! brew update --verbose; then exit 1; fi
+    # =========================================================================
+    # 2020-10-21: There seems to be a problem with Homebrew on the Github
+    # Actions macOS runner:
+    # https://github.com/actions/virtual-environments/issues/1811. This block
+    # of code is a *temporary* workaround, and should be removed soon. Probably
+    # by December 2020 at the latest. - Adarsh
+    # -------------------------------------------------------------------------
+    if (( CI )); then
+        brew uninstall openssl@1.0.2t
+        brew uninstall python@2.7.17
+        brew untap local/openssl
+        brew untap local/python2
+    fi
+    # ==========================================================================
+
+    if ! brew update --verbose; then
+        echo "The command 'brew update' failed. Exiting now."
+        exit 1
+    fi
 
     local homebrew_deps="fmt eigen"
     for dep in $COMMON_MACOS_DEPS $homebrew_deps; do

--- a/tools/install_dependencies
+++ b/tools/install_dependencies
@@ -7,7 +7,7 @@ set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" >/dev/null 2>&1 && pwd)"
 export ROOT
 
-echo "Installing ToMCAT faceAnalyzer dependencies."
+echo "Installing ToMCAT Team Mind dependencies."
 
 COMMON_MACOS_DEPS="cmake boost nlohmann-json gsl"
 __install_dependencies_using_macports() {


### PR DESCRIPTION
This PR:

1. Saves a metadata json file in the directory where the converted messages are.  This file contains a list of the filenames of successfully and unsuccessfully parsed message files. The list preserves the order in which the files were processed, allowing us to identify the origin of a given mission trial in given matrix of observations. 
2. Saves the initial timestamp (when the mission starts) for each successfully converted mission trial in the metadata file.
3. Saves the error that prevented a successful conversion of a message file in the metadata file.
4. Avoids parsing message files previously processed by an offline conversion by checking if the file is in the metadata file. New observations are appended to the rows of existing observation matrices in the output folder.