### PR TITLE
Sampling data nodes from even and odd time steps in different threads.

### DIFF
--- a/src/distribution/Gaussian.cpp
+++ b/src/distribution/Gaussian.cpp
@@ -34,12 +34,12 @@ namespace tomcat {
         //----------------------------------------------------------------------
         // Copy & Move constructors/assignments
         //----------------------------------------------------------------------
-        Gaussian::Gaussian(const Gaussian& Gaussian) {
-            this->parameters = Gaussian.parameters;
+        Gaussian::Gaussian(const Gaussian& gaussian) {
+            this->parameters = gaussian.parameters;
         }
 
-        Gaussian& Gaussian::operator=(const Gaussian& Gaussian) {
-            this->parameters = Gaussian.parameters;
+        Gaussian& Gaussian::operator=(const Gaussian& gaussian) {
+            this->parameters = gaussian.parameters;
             return *this;
         }
 

--- a/src/experiments/Experimentation.cpp
+++ b/src/experiments/Experimentation.cpp
@@ -91,10 +91,13 @@ namespace tomcat {
                                                    final_input_dir);
         }
 
-        void Experimentation::train_using_gibbs(int burn_in, int num_samples) {
+        void Experimentation::train_using_gibbs(int burn_in,
+                                                int num_samples,
+                                                int num_jobs) {
             this->trainer = make_shared<DBNSamplingTrainer>(
                 this->gen,
-                make_shared<GibbsSampler>(this->tomcat->get_model(), burn_in),
+                make_shared<GibbsSampler>(
+                    this->tomcat->get_model(), burn_in, num_jobs),
                 num_samples);
         }
 

--- a/src/experiments/Experimentation.h
+++ b/src/experiments/Experimentation.h
@@ -105,7 +105,8 @@ namespace tomcat {
 
             void load_model_from(const std::string& input_dir);
 
-            void train_using_gibbs(int burn_in, int num_samples);
+            void
+            train_using_gibbs(int burn_in, int num_samples, int num_jobs = 4);
 
             void save_model(const std::string& output_dir,
                             bool save_partials = false);

--- a/src/pgm/cpd/CPD.cpp
+++ b/src/pgm/cpd/CPD.cpp
@@ -16,12 +16,14 @@ namespace tomcat {
             : parent_node_order(parent_node_order) {
             this->init_id();
             this->fill_indexing_mapping();
+            this->sufficient_statistics_mutex = make_unique<mutex>();
         }
 
         CPD::CPD(vector<shared_ptr<NodeMetadata>>&& parent_node_order)
             : parent_node_order(move(parent_node_order)) {
             this->init_id();
             this->fill_indexing_mapping();
+            this->sufficient_statistics_mutex = make_unique<mutex>();
         }
 
         CPD::CPD(const vector<shared_ptr<NodeMetadata>>& parent_node_order,
@@ -30,6 +32,7 @@ namespace tomcat {
               distributions(distributions) {
             this->init_id();
             this->fill_indexing_mapping();
+            this->sufficient_statistics_mutex = make_unique<mutex>();
         }
 
         CPD::CPD(vector<shared_ptr<NodeMetadata>>&& parent_node_order,
@@ -38,6 +41,7 @@ namespace tomcat {
               distributions(move(distributions)) {
             this->init_id();
             this->fill_indexing_mapping();
+            this->sufficient_statistics_mutex = make_unique<mutex>();
         }
 
         CPD::~CPD() {}
@@ -92,6 +96,7 @@ namespace tomcat {
             this->parent_label_to_indexing = cpd.parent_label_to_indexing;
             this->parent_node_order = cpd.parent_node_order;
             this->distributions = cpd.distributions;
+            this->sufficient_statistics_mutex = make_unique<mutex>();
         }
 
         void CPD::update_dependencies(const Node::NodeMap& parameter_nodes_map,

--- a/src/pgm/cpd/CPD.h
+++ b/src/pgm/cpd/CPD.h
@@ -2,6 +2,7 @@
 
 #include <iterator>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -357,15 +358,23 @@ namespace tomcat {
             // Maps an indexing node's label to its indexing struct.
             TableOrderingMap parent_label_to_indexing;
 
+            // Controls racing conditions when multiple threads are trying to
+            // update the sufficient statistics. I decided to encapsulate it
+            // in a pointer to allow CPDs to have default move constructors
+            // as a mutex object cannot be moved. Since no copy or move will
+            // be performed by different threads (they just update the
+            // sufficient statistics), there's no need to deal with race
+            // condition when copying or moving an object of this class.
+            std::unique_ptr<std::mutex> sufficient_statistics_mutex;
+
           private:
             //------------------------------------------------------------------
             // Member functions
             //------------------------------------------------------------------
 
             /**
-             * Fill CPD's unique identifier formed by the concatenation of the
-            parent
-            // labels in alphabetical order delimited by comma.
+             * Fills CPD's unique identifier formed by the concatenation of the
+             * index nodes' labels in alphabetical order delimited by comma.
              */
             void init_id();
 

--- a/src/pgm/cpd/DirichletCPD.cpp
+++ b/src/pgm/cpd/DirichletCPD.cpp
@@ -1,4 +1,7 @@
 #include "pgm/cpd/DirichletCPD.h"
+
+#include <mutex>
+
 #include "pgm/ConstantNode.h"
 
 namespace tomcat {
@@ -107,6 +110,8 @@ namespace tomcat {
 
         void DirichletCPD::add_to_sufficient_statistics(
             const vector<double>& values) {
+
+            scoped_lock lock(*this->sufficient_statistics_mutex);
             for (int value : values) {
                 this->sufficient_statistics(value) += 1;
             }

--- a/src/pipeline/estimation/OnlineEstimation.cpp
+++ b/src/pipeline/estimation/OnlineEstimation.cpp
@@ -76,7 +76,8 @@ namespace tomcat {
                 // improved by creating perennial threads for each one of the
                 // estimators and keep tracking of the data point they have
                 // processed in the list of available data.
-                EvidenceSet new_data = get_next_data_from_pending_messages();
+                EvidenceSet new_data =
+                    this->get_next_data_from_pending_messages();
                 if (!new_data.empty()) {
                     for (auto estimator : this->estimators) {
                         EstimationProcess::estimate(estimator, new_data);
@@ -130,48 +131,6 @@ namespace tomcat {
                              << estimator_name << "/" << estimates.label;
 
                     this->publish(ss_topic.str(), to_string(estimates_vector));
-
-                    //                        if
-                    //                        (node_estimates.assignment.size()
-                    //                        == 0) {
-                    //                            // There will be estimates for
-                    //                            each one of the possible
-                    //                            node's assignments. We publish
-                    //                            each
-                    //                            // estimate in a different
-                    //                            topic. for (int assignment =
-                    //                            0; assignment <
-                    //                            node_estimates.estimates.size();
-                    //                            assignment++) {
-                    //                                ss_topic <<
-                    //                                this->config.estimates_topic
-                    //                                << "/"
-                    //                                         << estimator_name
-                    //                                         << "/"
-                    //                                         <<
-                    //                                         node_estimates.label
-                    //                                         << "/"
-                    //                                         << assignment;
-                    //
-                    //                                this->publish(ss_topic.str(),
-                    //                                              to_string(node_estimates.estimates[assignment]));
-                    //                            }
-                    //                        } else {
-                    //                            // Use the fixed assignment as
-                    //                            a topic ss_topic <<
-                    //                            this->config.estimates_topic
-                    //                            << "/"
-                    //                                     << estimator_name <<
-                    //                                     "/"
-                    //                                     <<
-                    //                                     node_estimates.label
-                    //                                     << "/"
-                    //                                     <<
-                    //                                     node_estimates.assignment;
-                    //
-                    //                            this->publish(ss_topic.str(),
-                    //                                          to_string(node_estimates.estimates[0]));
-                    //                        }
                 }
             }
             catch (out_of_range& e) {

--- a/src/pipeline/training/DBNSamplingTrainer.cpp
+++ b/src/pipeline/training/DBNSamplingTrainer.cpp
@@ -53,9 +53,14 @@ namespace tomcat {
             this->param_label_to_samples.push_back(
                 unordered_map<string, Tensor3>());
             int split_idx = this->param_label_to_samples.size() - 1;
-            for (const auto& param_label : model->get_parameter_node_labels()) {
-                this->param_label_to_samples[split_idx][param_label] =
-                    this->sampler->get_samples(param_label);
+            for (const auto& param_node : model->get_parameter_nodes()) {
+                if (!dynamic_pointer_cast<RandomVariableNode>(param_node)
+                         ->is_frozen()) {
+                    const string& param_label =
+                        param_node->get_metadata()->get_label();
+                    this->param_label_to_samples[split_idx][param_label] =
+                        this->sampler->get_samples(param_label);
+                }
             }
 
             this->update_model_from_partials(split_idx, false);

--- a/src/run_experiments_v2.cpp
+++ b/src/run_experiments_v2.cpp
@@ -420,5 +420,4 @@ int main(int argc, char* argv[]) {
     }
 
     execute_experiment(experiment_id);
-
 }


### PR DESCRIPTION
This PR refactors the Gibbs sampling procedure to work with multithreads. This will speed up the training and inference process. Nodes from even (and odd) time steps can be sampled independently as they are not part of each other's Markov blanket.