### PR TITLE
Improving particle filter estimation for multiple data points

### DIFF
--- a/src/distribution/Categorical.cpp
+++ b/src/distribution/Categorical.cpp
@@ -13,6 +13,7 @@ namespace tomcat {
         //----------------------------------------------------------------------
         // Constructors & Destructor
         //----------------------------------------------------------------------
+
         Categorical::Categorical(const shared_ptr<Node>& probabilities)
             : Distribution({probabilities}) {}
 

--- a/src/distribution/Distribution.h
+++ b/src/distribution/Distribution.h
@@ -113,16 +113,16 @@ namespace tomcat {
             void print(std::ostream& os) const;
 
             /**
-             *
-             * @param random_generators_per_job: random number generator to be
-             * used by individual threads
-             * @param num_samples: number of samples to generate
-             * @param parameter_idx: row of the node's assignment that holds the
-             * parameters of the distribution
-             *
-             * @return Matrix of samples generated for the distribution (one
-             * sample per row)
-             */
+            *
+            * @param random_generators_per_job: random number generator to be
+            * used by individual threads
+            * @param num_samples: number of samples to generate
+            * @param parameter_idx: row of the node's assignment that holds the
+            * parameters of the distribution
+            *
+            * @return Matrix of samples generated for the distribution (one
+            * sample per row)
+            */
             Eigen::MatrixXd sample_many(
                 std::vector<std::shared_ptr<gsl_rng>> random_generator_per_job,
                 int num_samples,

--- a/src/pipeline/estimation/Estimator.cpp
+++ b/src/pipeline/estimation/Estimator.cpp
@@ -96,7 +96,7 @@ namespace tomcat {
         }
 
         void Estimator::cleanup() {
-            this->estimates.estimates.clear();
+            this->prepare();
             this->cumulative_estimates.estimates.clear();
         }
 

--- a/src/pipeline/estimation/ParticleFilterEstimator.h
+++ b/src/pipeline/estimation/ParticleFilterEstimator.h
@@ -66,8 +66,6 @@ namespace tomcat {
             //------------------------------------------------------------------
             // Member functions
             //------------------------------------------------------------------
-            void cleanup() override;
-
             void prepare() override;
 
             void keep_estimates() override;
@@ -108,7 +106,9 @@ namespace tomcat {
             // Data members
             //------------------------------------------------------------------
 
-            ParticleFilter filter;
+            ParticleFilter template_filter;
+
+            std::vector<ParticleFilter> filter_per_data_point;
 
             int last_time_step = -1;
 


### PR DESCRIPTION
This PR creates one particle filter per data point, which avoids having to clean and store pre computed samples whenever switching to another data point as data comes in a stream. 