### PR TITLE
Collecting distance to victims in FoV

### DIFF
--- a/src/converter/ASISTMultiPlayerMessageConverter.h
+++ b/src/converter/ASISTMultiPlayerMessageConverter.h
@@ -91,8 +91,16 @@ namespace tomcat {
             inline const static std::string PLAYER_MARKER2_IN_FOV_LABEL =
                 "PlayerMarker2InFoV";
             inline const static std::string
-                PLAYER_UNRESCUED_CLOSE_VICTIM_IN_FOV =
-                "VictimInPlayerFoV";
+                PLAYER_UNRESCUED_CLOSE_VICTIM_IN_FOV = "VictimInPlayerFoV";
+            inline const static std::string
+                PLAYER_VICTIM_DIST_IN_FOV_LABEL =
+                "PlayerVictimDistInFoV";
+            inline const static std::string
+                PLAYER_REGULAR_VICTIM_DIST_IN_FOV_LABEL =
+                    "PlayerRegularVictimDistInFoV";
+            inline const static std::string
+                PLAYER_CRITICAL_VICTIM_DIST_IN_FOV_LABEL =
+                    "PlayerCriticalVictimDistInFoV";
 
             inline const static std::string
                 PLAYER1_PLAYER_MARKER1_IN_FOV_LABEL =
@@ -655,6 +663,9 @@ namespace tomcat {
             std::vector<Tensor3> room_regular_victim_in_fov_per_player;
             std::vector<Tensor3> room_critical_victim_in_fov_per_player;
             std::vector<Tensor3> unrescued_close_victim_in_fov_per_player;
+            std::vector<Tensor3> victim_dist_in_fov_per_player;
+            std::vector<Tensor3> regular_victim_dist_in_fov_per_player;
+            std::vector<Tensor3> critical_victim_dist_in_fov_per_player;
 
             std::vector<Tensor3> player1_marker1_in_fov_per_player;
             std::vector<Tensor3> player2_marker1_in_fov_per_player;

--- a/src/experiments/Experimentation.cpp
+++ b/src/experiments/Experimentation.cpp
@@ -64,10 +64,16 @@ namespace tomcat {
                 final_params_dir = params_dir;
             }
             else {
-                splitter =
-                    DataSplitter(data, num_folds, this->random_generator);
                 final_params_dir = fmt::format("{}/fold{{}}", params_dir);
-                splitter.save_indices(params_dir);
+                try {
+                    // Tries to load pre-existent indices from the params folder.
+                    splitter =
+                        DataSplitter(data, params_dir);
+                } catch (TomcatModelException e) {
+                    splitter =
+                        DataSplitter(data, num_folds, this->random_generator);
+                    splitter.save_indices(params_dir);
+                }
             }
 
             DBNSaver model_saver(

--- a/src/pgm/JSONModelParser.cpp
+++ b/src/pgm/JSONModelParser.cpp
@@ -544,7 +544,8 @@ namespace tomcat {
             vector<shared_ptr<D>> distributions;
             for (int i = 0; i < num_distributions; i++) {
                 NodePtrVec parameters;
-                for (const string& token : tokens) {
+                for (string& token : tokens) {
+                    boost::trim(token);
                     if (EXISTS(token, this->rv_nodes)) {
                         const auto& parameter_node =
                             this->rv_nodes.at(token)[i];

--- a/src/pgm/cpd/CPD.cpp
+++ b/src/pgm/cpd/CPD.cpp
@@ -1655,7 +1655,7 @@ namespace tomcat {
             for (int i = initial_row; i < initial_row + num_rows; i++) {
                 const auto& distribution =
                     this->distributions[distribution_indices[i]];
-                pdfs[i] =
+                pdfs[i - initial_row] =
                     distribution->get_pdf(cpd_owner->get_assignment().row(i));
             }
 


### PR DESCRIPTION
- Parses distance to the victims in the players' FoV from the testbed messages.
- Corrects a small bug that was breaking inference in models with continuous random variables.