### PR TITLE
Canceling marker intervention on marker removal

### DIFF
--- a/src/asist/study3/ASISTStudy3InterventionEstimator.h
+++ b/src/asist/study3/ASISTStudy3InterventionEstimator.h
@@ -168,9 +168,8 @@ namespace tomcat::model {
                                            int time_step,
                                            const EvidenceSet& new_data);
 
-        static bool did_player_remove_marker(
+        static bool did_any_player_remove_marker(
             const ASISTStudy3MessageConverter::Marker& marker,
-            int player_order,
             int time_step,
             const EvidenceSet& new_data);
 
@@ -209,8 +208,7 @@ namespace tomcat::model {
                                            int time_step,
                                            const EvidenceSet& new_data);
 
-        static bool is_player_being_released(int player_order,
-                                             int time_step,
+        static bool is_player_being_released(int time_step,
                                              const EvidenceSet& new_data,
                                              const std::string& threat_id);
 


### PR DESCRIPTION
I was previously canceling this intervention only if the player who placed the marker removed it. However, the intervention will be activated and delivered if the player leaves the area they are currently in. If another player removes the marker before the intervention is activated, it means they are in the same area as the player who placed the marker in the first place. Therefore, it makes sense to cancel the intervention, because the player who placed the marker is most likely aware of the marker removal.